### PR TITLE
01 Add Double Number

### DIFF
--- a/app/controllers/hello_world_controller.rb
+++ b/app/controllers/hello_world_controller.rb
@@ -1,5 +1,7 @@
 class HelloWorldController < ApplicationController
   def index
     @hello_world_props = { name: "Stranger" }
+
+    @double_number_props = { value: "10" }
   end
 end

--- a/app/views/hello_world/index.html.erb
+++ b/app/views/hello_world/index.html.erb
@@ -1,3 +1,7 @@
-<h1 class="alert alert-info this-works">Hello World</h1>
+<h1>Hello World</h1>
 <%= react_component("HelloWorldApp", props: @hello_world_props, prerender: false) %>
 
+<hr/>
+
+<h1>React Double Number Example</h1>
+<%= react_component("DoubleNumberApp", props: @double_number_props, prerender: false) %>

--- a/client/app/bundles/HelloWorld/components/DoubleNumber.jsx
+++ b/client/app/bundles/HelloWorld/components/DoubleNumber.jsx
@@ -1,0 +1,26 @@
+import React, { PropTypes } from 'react';
+
+const DoubleNumber = ({ value, updateValue }) => (
+  <form>
+    <label htmlFor="number">
+      Number to double:
+    </label>
+    <input
+      type="text" value={value} id="number"
+      onChange={(e) => updateValue(e.target.value)}
+    />
+    <hr />
+    {
+      isNaN(value)
+        ? 'Invalid value'
+        : `Number doubled is ${parseFloat(value) * 2}`
+    }
+  </form>
+);
+
+DoubleNumber.propTypes = {
+  value: PropTypes.string.isRequired,
+  updateValue: PropTypes.func.isRequired,
+};
+
+export default DoubleNumber;

--- a/client/app/bundles/HelloWorld/containers/DoubleNumberContainer.jsx
+++ b/client/app/bundles/HelloWorld/containers/DoubleNumberContainer.jsx
@@ -1,0 +1,28 @@
+import React, { PropTypes } from 'react';
+import DoubleNumber from '../components/DoubleNumber';
+
+export default class DoubleNumberContainer extends React.Component {
+  static propTypes = {
+    value: PropTypes.string.isRequired,
+  };
+
+  constructor(props, context) {
+    super(props, context);
+    this.state = { value: this.props.value };
+  }
+
+  updateValue = (value) => {
+    this.setState({ value });
+  };
+
+  render() {
+    return (
+      <div>
+        <DoubleNumber
+          value={this.state.value}
+          updateValue={this.updateValue}
+        />
+      </div>
+    );
+  }
+}

--- a/client/app/bundles/HelloWorld/startup/DoubleNumberApp.jsx
+++ b/client/app/bundles/HelloWorld/startup/DoubleNumberApp.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactOnRails from 'react-on-rails';
+
+import DoubleNumberContainer from '../containers/DoubleNumberContainer';
+
+const DoubleNumberApp = (props) => (
+  <DoubleNumberContainer {...props} />
+);
+
+ReactOnRails.register({ DoubleNumberApp });

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -10,6 +10,7 @@ const config = {
     'es5-shim/es5-sham',
     'babel-polyfill',
     './app/bundles/HelloWorld/startup/HelloWorldApp',
+    './app/bundles/HelloWorld/startup/DoubleNumberApp',
   ],
 
   output: {


### PR DESCRIPTION
Corresponding Doc: https://docs.google.com/document/d/1TMIGnVTCKHVYYIOL13uUQZtio5WWmqCPMutg0Ru6fO8/edit#

Starting with a new Rails app and a non-redux installation of React on Rails, we’ll add another component that will double a number.

This example shows how to add a simple react component to a React on Rails installation. The simple component will double a number or display a message if the value entered is not a number.